### PR TITLE
Use bcrypt instead of SHA2-512. The SHA2 in this setup is insecure.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/README.md
+++ b/README.md
@@ -4,6 +4,13 @@ Allow the use of properly hashed passwords in [etherpad-lite]. Uses [bcrypt](htt
 
 Rework of the insecure SHA2-512 password hashing which was used up to version 1.0.2.
 
+## Generate the hashes
+
+```Shell
+apt-get install -yqq python-bcrypt
+python -c 'from passlib.hash import bcrypt;print(bcrypt.encrypt("password", rounds=10))'
+```
+
 ## Usage
 
 This plugin allows the usage of hash values for authentication in `settings.json`:

--- a/README.md
+++ b/README.md
@@ -1,14 +1,33 @@
-This plugin allows the usage of hash values for authentoication in settings.json
+# ep_hash_auth
 
-  "users": {
-	"admin": {"password": "admin","is_admin": true},
-	"y": {"is_admin": true, "hash": "b2112aa73994bd7cbb07732326ee102d585e706bb2e4fb878df5b5706ea92522f67b9f9dbc0208e2bd5b0f9cb21221bfb970f36a63e27e1a128ebc44d1ea5976"}
-  }
+Allow the use of properly hashed passwords in [etherpad-lite]. Uses [bcrypt](https://www.npmjs.com/package/bcrypt) for password hashing and salting.
 
-optionally specify hash type and digest, defaults are:
+Rework of the insecure SHA2-512 password hashing which was used up to version 1.0.2.
 
-  "ep_hash_auth": {
-    "hash_typ": "sha512",
-    "hash_dig": "hex"
-  },
-  
+## Usage
+
+This plugin allows the usage of hash values for authentication in `settings.json`:
+
+```JSON
+"users": {
+  "admin": {"password": "admin","is_admin": true},
+  "y": {"is_admin": true, "hash": "b2112aa73994bd7cbb07732326ee102d585e706bb2e4fb878df5b5706ea92522f67b9f9dbc0208e2bd5b0f9cb21221bfb970f36a63e27e1a128ebc44d1ea5976"}
+},
+```
+
+Optionally specify hash type and digest, defaults are:
+
+```JSON
+"ep_hash_auth": {
+  "hash_typ": "sha512",
+  "hash_dig": "hex"
+},
+```
+
+## Credits
+
+* István Király (original author)
+* [LaKing](https://github.com/LaKing) (maintainer)
+* [Robin `ypid` Schneider](https://github.com/ypid)
+
+[etherpad-lite]: https://github.com/ether/etherpad-lite

--- a/ep_hash_auth.js
+++ b/ep_hash_auth.js
@@ -1,32 +1,28 @@
-// hash based authentication for etherpad
-// 2014 - István Király - LaKing@D250.hu
+/* hash based authentication for etherpad
+ * 2014 - István Király - LaKing@D250.hu
+ * Reworked by Robin Schneider <ypid@riseup.net> to allow the use of proper password hash algorithms.
+ */
 
 var settings = require('ep_etherpad-lite/node/utils/Settings');
 var authorManager = require('ep_etherpad-lite/node/db/AuthorManager');
-var crypto = require('crypto');
-
-var hash_typ = "sha512";
-var hash_dig = "hex";
-
-if (settings.ep_hash_auth) {
-    if (settings.ep_hash_auth.hash_typ) hash_typ = settings.ep_hash_auth.hash_typ;
-    if (settings.ep_hash_auth.hash_dig) hash_dig = settings.ep_hash_auth.hash_dig;
-}
+var bcrypt = require('bcrypt');
 
 exports.authenticate = function(hook_name, context, cb) {
-  console.debug('ep_hash_auth.authenticate');
+  // console.debug('ep_hash_auth.authenticate');
+  // console.log(context.req.headers.authorization);
 
   if (context.req.headers.authorization && context.req.headers.authorization.search('Basic ') === 0) {
     var userpass = new Buffer(context.req.headers.authorization.split(' ')[1], 'base64').toString().split(":")
-    var username = userpass.shift();
+      var username = userpass.shift();
     var password = userpass.join(':');
-    var hash = crypto.createHash(hash_typ).update(password).digest(hash_dig);
+    // console.log(username);
+    // console.log(password);
 
     // Authenticate user via settings.json
     if (settings.users[username] != undefined) {
       // hash defined in "hash" of users
       if (settings.users[username].hash != undefined) {
-        if (settings.users[username].hash == hash) {
+        if (bcrypt.compareSync(password, settings.users[username].hash)) {
           settings.users[username].username = username;
           context.req.session.user = settings.users[username];
           return cb([true]);

--- a/ep_hash_auth.js
+++ b/ep_hash_auth.js
@@ -6,23 +6,38 @@
 var settings = require('ep_etherpad-lite/node/utils/Settings');
 var authorManager = require('ep_etherpad-lite/node/db/AuthorManager');
 var bcrypt = require('bcrypt');
+var crypto = require('crypto');
+
+var hash_typ = "bcrypt";
+var hash_dig = "hex";
+
+if (settings.ep_hash_auth) {
+    if (settings.ep_hash_auth.hash_typ) hash_typ = settings.ep_hash_auth.hash_typ;
+    if (settings.ep_hash_auth.hash_dig) hash_dig = settings.ep_hash_auth.hash_dig;
+}
 
 exports.authenticate = function(hook_name, context, cb) {
-  // console.debug('ep_hash_auth.authenticate');
-  // console.log(context.req.headers.authorization);
+  console.debug('ep_hash_auth.authenticate');
+  console.log(context.req.headers.authorization);
 
   if (context.req.headers.authorization && context.req.headers.authorization.search('Basic ') === 0) {
     var userpass = new Buffer(context.req.headers.authorization.split(' ')[1], 'base64').toString().split(":")
-      var username = userpass.shift();
+    var username = userpass.shift();
     var password = userpass.join(':');
-    // console.log(username);
-    // console.log(password);
+    if (hash_typ.match(/sha/i)) {
+      var hash = crypto.createHash(hash_typ).update(password).digest(hash_dig);
+    }
+    console.log(username);
+    console.log(password);
 
     // Authenticate user via settings.json
     if (settings.users[username] != undefined) {
       // hash defined in "hash" of users
       if (settings.users[username].hash != undefined) {
-        if (bcrypt.compareSync(password, settings.users[username].hash)) {
+        if (
+              (typeof hash === 'string' && settings.users[username].hash == hash) ||
+              (hash_typ === 'bcrypt' && bcrypt.compareSync(password, settings.users[username].hash))
+            ) {
           settings.users[username].username = username;
           context.req.session.user = settings.users[username];
           return cb([true]);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
   "author": {
     "name": "István Király"
   },
+  "contributors": {
+    "name": "Robin Schneider",
+    "email": "ypid@riseup.net",
+    "url": "http://github.com/ypid"
+  },
   "license": "GPL-3.0+",
   "readme": "This plugin allows the usage of hash values for authentoication in settings.json\n\n  \"users\": {\n\t\"admin\": {\"password\": \"admin\",\"is_admin\": true},\n\t\"y\": {\"is_admin\": true, \"hash\": \"b2112aa73994bd7cbb07732326ee102d585e706bb2e4fb878df5b5706ea92522f67b9f9dbc0208e2bd5b0f9cb21221bfb970f36a63e27e1a128ebc44d1ea5976\"}\n  }\n\noptionally specify hash type and digest, defaults are:\n\n  \"ep_hash_auth\": {\n    \"hash_typ\": \"sha512\",\n    \"hash_dig\": \"hex\"\n  },\n  \n",
   "readmeFilename": "README.md",
@@ -23,5 +28,8 @@
     "shasum": "b70bac22435e00a0196fee2e7db1b228dc5bebf5"
   },
   "_from": "ep_hash_auth@",
-  "_resolved": "https://registry.npmjs.org/ep_hash_auth/-/ep_hash_auth-1.0.2.tgz"
+  "_resolved": "https://registry.npmjs.org/ep_hash_auth/-/ep_hash_auth-1.0.2.tgz",
+  "dependencies": {
+    "bcrypt": "*"
+  }
 }


### PR DESCRIPTION
SHA2 with one round for storing passwords is anything but secure these
days. Bcrypt seems to be the better option.

Related: https://github.com/debops/ansible-etherpad/issues/14

@LaKing Thanks for putting up the git repo for it :+1: 