### PR TITLE
Fix instructions for generating bcrypt hashes using Python

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ The hash_adm parameter defines the role of file-authenticated users, by default 
 
 ## Generate the hashes
 ```Shell
- 	 apt-get install -yqq python-bcrypt
- 	 python -c 'from passlib.hash import bcrypt;print(bcrypt.encrypt("password", rounds=10))'
+apt-get install -yqq python-bcrypt
+python -c 'import bcrypt; print(bcrypt.hashpw(b"password", bcrypt.gensalt(rounds=10, prefix=b"2a")))'
 ```
 
 ## Credits


### PR DESCRIPTION
The current instructions for generating bcrypt hashes using Python are faulty:

Passlib is not actually required (and would have to be installed as well), but the Node bcrypt module is very picky about the [hash prefix](https://stackoverflow.com/a/36225192) and won't accept Python's default of "2b".

This command line should work with both Python 2 and 3.